### PR TITLE
Tina/completed requests positioning

### DIFF
--- a/src/components/OwnerActiveRequest/OwnerActiveRequest.jsx
+++ b/src/components/OwnerActiveRequest/OwnerActiveRequest.jsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-
-import { useEffect, useState } from 'react';
-
+import { useEffect} from 'react';
 import './OwnerActiveRequest.css';
 
 function OwnerActiveRequest() {
   const history = useHistory();
-  const requests = useSelector((store) => store.job.owner_requests);
   const dispatch = useDispatch();
+  const requests = useSelector((store) => store.job.owner_requests);
   const activeRequests = requests.filter(
     (request) => request.status !== 'complete',
   );

--- a/src/components/OwnerActiveRequest/OwnerActiveRequest.jsx
+++ b/src/components/OwnerActiveRequest/OwnerActiveRequest.jsx
@@ -26,7 +26,7 @@ function OwnerActiveRequest() {
   return (
     <div className="active-box-container">
       <div className="active-request-header">
-        <h2>Property</h2> 
+        {/* <h2>Property</h2>  */}
         <div className="active-request-content">
           {/* <div className="active-request-image">Insert Image Property Here</div> */}
           <div className="job-list-container">

--- a/src/components/OwnerActiveRequestPage/OwnerActiveRequestPage.jsx
+++ b/src/components/OwnerActiveRequestPage/OwnerActiveRequestPage.jsx
@@ -1,13 +1,25 @@
 import React from 'react';
+import { useHistory} from 'react-router-dom';
 import OwnerActiveRequest from '../OwnerActiveRequest/OwnerActiveRequest';
 
+
 function OwnerActiveRequestList() {
-  console.log('in the OwnerActiveRequestPage');
+  const history = useHistory();
+
+  const handleToHome = () => {
+    history.push('/');
+  };
 
   return (
     <div>
       <p>Active Requests:</p>
       <OwnerActiveRequest />
+      <br/>
+      <div>
+        <button className="btn" onClick={handleToHome}>
+          Back
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/OwnerActiveRequestPage/OwnerActiveRequestPage.jsx
+++ b/src/components/OwnerActiveRequestPage/OwnerActiveRequestPage.jsx
@@ -7,12 +7,12 @@ function OwnerActiveRequestList() {
   const history = useHistory();
 
   const handleToHome = () => {
-    history.push('/');
+    history.push('/OwnerViewRequestsPage');
   };
 
   return (
     <div>
-      <p>Active Requests:</p>
+      <h3>Active Requests:</h3>
       <OwnerActiveRequest />
       <br/>
       <div>

--- a/src/components/OwnerActiveRequestPage/OwnerActiveRequestPage.jsx
+++ b/src/components/OwnerActiveRequestPage/OwnerActiveRequestPage.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useHistory} from 'react-router-dom';
 import OwnerActiveRequest from '../OwnerActiveRequest/OwnerActiveRequest';
 
-
 function OwnerActiveRequestList() {
   const history = useHistory();
 

--- a/src/components/OwnerActiveRequestPage/OwnerActiveRequestPage.jsx
+++ b/src/components/OwnerActiveRequestPage/OwnerActiveRequestPage.jsx
@@ -6,7 +6,7 @@ import OwnerActiveRequest from '../OwnerActiveRequest/OwnerActiveRequest';
 function OwnerActiveRequestList() {
   const history = useHistory();
 
-  const handleToHome = () => {
+  const goBack = () => {
     history.push('/OwnerViewRequestsPage');
   };
 
@@ -16,7 +16,7 @@ function OwnerActiveRequestList() {
       <OwnerActiveRequest />
       <br/>
       <div>
-        <button className="btn" onClick={handleToHome}>
+        <button className="btn" onClick={goBack}>
           Back
         </button>
       </div>

--- a/src/components/OwnerCompletedRequest/OwnerCompletedRequest.jsx
+++ b/src/components/OwnerCompletedRequest/OwnerCompletedRequest.jsx
@@ -21,6 +21,10 @@ function OwnerCompletedRequest() {
     dispatch({ type: "FETCH_OWNER_REQUESTS" });
   }, []);
 
+  const handleToHome = () => {
+    history.push('/OwnerViewRequestsPage');
+  };
+
   // Render
   return (
     // <div className="job-list-body">
@@ -58,7 +62,13 @@ function OwnerCompletedRequest() {
           <button className="btn" onClick={() => handleViewRequest(request)}>View</button>
           <button className="btn">Delete</button>
         </div>
-          )})};
+          )})}
+      {/* <br/> */}
+      {/* <div>
+        <button className="btn" onClick={handleToHome}>
+          Back
+        </button>
+      </div> */}
     </div>
   );
 }

--- a/src/components/OwnerCompletedRequest/OwnerCompletedRequest.jsx
+++ b/src/components/OwnerCompletedRequest/OwnerCompletedRequest.jsx
@@ -25,6 +25,11 @@ function OwnerCompletedRequest() {
     history.push('/OwnerViewRequestsPage');
   };
 
+  const handleViewRequest = (request) => {
+    console.log(request.id);
+    history.push(`/OwnerRequestDetails/${request.id}`);
+  };
+
   // Render
   return (
     // <div className="job-list-body">
@@ -62,13 +67,7 @@ function OwnerCompletedRequest() {
           <button className="btn" onClick={() => handleViewRequest(request)}>View</button>
           <button className="btn">Delete</button>
         </div>
-          )})}
-      {/* <br/> */}
-      {/* <div>
-        <button className="btn" onClick={handleToHome}>
-          Back
-        </button>
-      </div> */}
+          )})} 
     </div>
   );
 }

--- a/src/components/OwnerCompletedRequest/OwnerCompletedRequest.jsx
+++ b/src/components/OwnerCompletedRequest/OwnerCompletedRequest.jsx
@@ -8,39 +8,57 @@ import JobItem from '../JobItem/JobItem';
 import './OwnerCompletedRequest.css';
 
 function OwnerCompletedRequest() {
-  console.log('in completed request component');
+  const requests = useSelector((store) => store.job.owner_requests);
   const history = useHistory();
   const dispatch = useDispatch();
-  const jobs = useSelector((store) => store.job.jobs);
+  const completedRequests = requests.filter(
+    (request) => request.status === 'complete',
+  );
+  // const jobs = useSelector((store) => store.job.jobs);
 
   useEffect(() => {
-    dispatch({ type: 'FETCH_JOBS' });
+    // dispatch({ type: 'FETCH_JOBS' });
+    dispatch({ type: "FETCH_OWNER_REQUESTS" });
   }, []);
 
   // Render
   return (
-    <div className="job-list-body">
-      <div className="job-list-container">
-        {jobs.length ? (
-          jobs.map((job) => (
-            <div>
-              <JobItem
-                key={job.id}
-                id={job.id}
-                owner={job.username}
-                street={job.street}
-                city={job.city}
-                state={job.state}
-                zip={job.zipcode}
-                price={job.price}
-                date={job.date_completed_by}
-              />
-            </div>
-          ))
-        ) : (
-          <p>no jobs found</p>
-        )}
-      </div>
+    // <div className="job-list-body">
+    //   <div className="job-list-container">
+    //     {jobs.length ? (
+    //       jobs.map((job) => (
+    //         <div>
+    //           <JobItem
+    //             key={job.id}
+    //             id={job.id}
+    //             owner={job.username}
+    //             street={job.street}
+    //             city={job.city}
+    //             state={job.state}
+    //             zip={job.zipcode}
+    //             price={job.price}
+    //             date={job.date_completed_by}
+    //           />
+    //         </div>
+    //       ))
+    //     ) : (
+    //       <p>no jobs found</p>
+    //     )}
+    //   </div>
+    // </div>
+    <div className='job-list-container'>{completedRequests.map((request) => {
+      return (
+        <div className="job-item-body" key={request.id}>
+          <p>
+            {request.street} {request.city} {request.state}{' '}
+            {request.zipcode}
+          </p>
+          <p>{new Date(request.date_completed_by).toLocaleDateString('en-US')}</p>
+          <p>${request.price}</p>
+          <button className="btn" onClick={() => handleViewRequest(request)}>View</button>
+          <button className="btn">Delete</button>
+        </div>
+          )})};
     </div>
   );
 }

--- a/src/components/OwnerCompletedRequestPage/OwnerCompletedRequestPage.jsx
+++ b/src/components/OwnerCompletedRequestPage/OwnerCompletedRequestPage.jsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useEffect } from 'react';
 
 import JobItem from '../JobItem/JobItem';
+import OwnerCompletedRequest from '../OwnerCompletedRequest/OwnerCompletedRequest';
 
 function OwnerCompletedRequestPage() {
   console.log('in the OwnerCompletedRequestPage');
@@ -15,31 +16,35 @@ function OwnerCompletedRequestPage() {
   }, []);
 
   return (
+    // <div>
+    //   <h2>Completed Requests</h2>
+    //   <div className="job-list-body">
+    //     <div className="job-list-container">
+    //       {jobs.length ? (
+    //         jobs.map((job) => (
+    //           <div>
+    //             <JobItem
+    //               key={job.id}
+    //               id={job.id}
+    //               owner={job.username}
+    //               street={job.street}
+    //               city={job.city}
+    //               state={job.state}
+    //               zip={job.zipcode}
+    //               price={job.price}
+    //               date={job.date_completed_by}
+    //             />
+    //           </div>
+    //         ))
+    //       ) : (
+    //         <p>no jobs found</p>
+    //       )}
+    //     </div>
+    //   </div>{' '}
+    // </div>
     <div>
-      <h2>Completed Requests</h2>
-      <div className="job-list-body">
-        <div className="job-list-container">
-          {jobs.length ? (
-            jobs.map((job) => (
-              <div>
-                <JobItem
-                  key={job.id}
-                  id={job.id}
-                  owner={job.username}
-                  street={job.street}
-                  city={job.city}
-                  state={job.state}
-                  zip={job.zipcode}
-                  price={job.price}
-                  date={job.date_completed_by}
-                />
-              </div>
-            ))
-          ) : (
-            <p>no jobs found</p>
-          )}
-        </div>
-      </div>{' '}
+      <p>Completed Requests:</p>
+      <OwnerCompletedRequest />
     </div>
   );
 }

--- a/src/components/OwnerCompletedRequestPage/OwnerCompletedRequestPage.jsx
+++ b/src/components/OwnerCompletedRequestPage/OwnerCompletedRequestPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect } from 'react';
 
@@ -9,11 +9,16 @@ import OwnerCompletedRequest from '../OwnerCompletedRequest/OwnerCompletedReques
 function OwnerCompletedRequestPage() {
   console.log('in the OwnerCompletedRequestPage');
   const dispatch = useDispatch();
+  const history = useHistory();
   const jobs = useSelector((store) => store.job.jobs);
 
   useEffect(() => {
     dispatch({ type: 'FETCH_JOBS' });
   }, []);
+
+  const goBack = () => {
+    history.push('/OwnerViewRequestsPage');
+  };
 
   return (
     // <div>
@@ -45,6 +50,12 @@ function OwnerCompletedRequestPage() {
     <div>
       <h3>Completed Requests:</h3>
       <OwnerCompletedRequest />
+      <br/>
+       <div>
+        <button className="btn" onClick={goBack}>
+          Back
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/OwnerCompletedRequestPage/OwnerCompletedRequestPage.jsx
+++ b/src/components/OwnerCompletedRequestPage/OwnerCompletedRequestPage.jsx
@@ -2,19 +2,16 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect } from 'react';
-
-import JobItem from '../JobItem/JobItem';
 import OwnerCompletedRequest from '../OwnerCompletedRequest/OwnerCompletedRequest';
 
 function OwnerCompletedRequestPage() {
-  console.log('in the OwnerCompletedRequestPage');
   const dispatch = useDispatch();
   const history = useHistory();
   const jobs = useSelector((store) => store.job.jobs);
 
-  useEffect(() => {
-    dispatch({ type: 'FETCH_JOBS' });
-  }, []);
+  // useEffect(() => {
+  //   dispatch({ type: 'FETCH_JOBS' });
+  // }, []);
 
   const goBack = () => {
     history.push('/OwnerViewRequestsPage');

--- a/src/components/OwnerCompletedRequestPage/OwnerCompletedRequestPage.jsx
+++ b/src/components/OwnerCompletedRequestPage/OwnerCompletedRequestPage.jsx
@@ -43,7 +43,7 @@ function OwnerCompletedRequestPage() {
     //   </div>{' '}
     // </div>
     <div>
-      <p>Completed Requests:</p>
+      <h3>Completed Requests:</h3>
       <OwnerCompletedRequest />
     </div>
   );

--- a/src/components/OwnerRequestDetails/OwnerRequestDetails.jsx
+++ b/src/components/OwnerRequestDetails/OwnerRequestDetails.jsx
@@ -44,7 +44,7 @@ function OwnerRequestDetails() {
             </div>
             <div className="grid-button-section">
               <div className="request-details-cancel">
-                <button className="btn" onClick={() => goBack()}>back</button>
+                <button className="btn" onClick={() => goBack()}>Back</button>
               </div>
             </div>
           </div>

--- a/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.css
+++ b/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.css
@@ -24,6 +24,17 @@
   /* flex-wrap: wrap; */
 }
 
+.active-requests-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  /* height: 30px; */
+}
+
+/* .active-requests-view-btn {
+  background-color: transparent;
+} */
+
 .list-header {
   background-color: #94c5cc;
   width: 50rem;

--- a/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.css
+++ b/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.css
@@ -28,15 +28,28 @@
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  /* height: 30px; */
 }
 
-/* .active-requests-view-btn {
-  background-color: transparent;
-} */
+.completed-requests-header {
+  background-color: #da9494;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+}
+
+.requests-page-view-btn {
+  background-color: black;
+  border-color: #454B66;
+  color: azure;
+  border-width: 1px 1px 3px;
+  border-radius: 4px;
+  outline: 0;
+  cursor: pointer;
+}
 
 .list-header {
-  background-color: #94c5cc;
+  /* background-color: #94c5cc; */
   width: 50rem;
   display: inline;
 }

--- a/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.css
+++ b/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.css
@@ -21,7 +21,7 @@
   gap: 3rem;
 
   width: 80rem;
-  flex-wrap: wrap;
+  /* flex-wrap: wrap; */
 }
 
 .list-header {
@@ -33,6 +33,11 @@
 .break {
   flex-basis: 100%;
   height: 0;
+}
+
+.job-list-body {
+  display: flex;
+flex-direction: column
 }
 /* .list-active-requests,
 .list-completed-requests {

--- a/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.jsx
+++ b/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.jsx
@@ -60,9 +60,9 @@ function OwnerViewRequestsPage() {
         <div className="active-box-container">
           <button className='btn' onClick={viewCompletedList}>Completed Requests:</button>
           {/* <OwnerCompletedRequest /> */}
-          {completedRequests.map((request) => {
+          <div className='job-list-container'>{completedRequests.map((request) => {
             return (
-              <div className="completed-requests" key={request.id}>
+              <div className="job-item-body" key={request.id}>
                 <p>
                   {request.street} {request.city} {request.state}{' '}
                   {request.zipcode}
@@ -74,6 +74,7 @@ function OwnerViewRequestsPage() {
               </div>
             );
           })}
+          </div>
         </div>
       </div>
       <br />

--- a/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.jsx
+++ b/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.jsx
@@ -59,8 +59,8 @@ function OwnerViewRequestsPage() {
             <h4> Completed Requests:</h4>
             <button className="requests-page-view-btn" onClick={()=>{history.push(`/OwnerCompletedRequestsPage`)}}>view</button>
           </div>
-          {/* <OwnerCompletedRequest /> */}
-          <div className='job-list-container'>{completedRequests.map((request) => {
+          <OwnerCompletedRequest />
+          {/* <div className='job-list-container'>{completedRequests.map((request) => {
             return (
               <div className="job-item-body" key={request.id}>
                 <p>
@@ -74,7 +74,7 @@ function OwnerViewRequestsPage() {
               </div>
             );
           })}
-          </div>
+          </div> */}
         </div>
       </div>
       <br />

--- a/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.jsx
+++ b/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useHistory, Link } from 'react-router-dom';
+import { useHistory} from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect, useState } from 'react';
 
@@ -22,13 +22,7 @@ function OwnerViewRequestsPage() {
 
   // button to send user back to OwnersHomePage
   const handleToHome = () => {
-    console.log('handleToHome clicked!');
     history.push('/');
-  };
-
-  const viewCompletedList = () => {
-    console.log('viewCompletedList clicked');
-    history.push('OwnerCompletedRequestsPage');
   };
 
   const handleViewRequest = (request) => {
@@ -39,12 +33,12 @@ function OwnerViewRequestsPage() {
   return (
     <div>
       <div>
-        <h3>View Requests</h3>
+        <h2>View Requests</h2>
       </div>
 
       <div className="job-list-body">
         <div className="list-header">
-          <p>Select a list to view:</p>
+          <h3>Select a list to view:</h3>
         </div>
 
         {/* render 4 recent active requests */}
@@ -88,7 +82,7 @@ function OwnerViewRequestsPage() {
       {/* button to send back to home */}
       <div>
         <button className="btn" onClick={handleToHome}>
-          back
+          Back
         </button>
       </div>
     </div>

--- a/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.jsx
+++ b/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.jsx
@@ -51,9 +51,7 @@ function OwnerViewRequestsPage() {
         <div className="list-active-requests">
           <div className="active-requests-header">
             <h4>Active Requests:</h4>
-            <div className="active-requests-view-btn">
-              <button onClick={()=>{history.push(`/OwnerActiveRequestsPage`)}}>view</button>
-            </div>
+            <button className="requests-page-view-btn" onClick={()=>{history.push(`/OwnerActiveRequestsPage`)}}>view</button>
           </div>
           <OwnerActiveRequest />
         </div>
@@ -63,8 +61,10 @@ function OwnerViewRequestsPage() {
 
         {/* render 4 recent completed requests */}
         <div className="active-box-container">
-          {/* <button className='btn' onClick={viewCompletedList}>Completed Requests:</button> */}
-          <Link to="/OwnerCompletedRequestsPage"> Completed Requests:</Link>
+          <div className='completed-requests-header'>
+            <h4> Completed Requests:</h4>
+            <button className="requests-page-view-btn" onClick={()=>{history.push(`/OwnerCompletedRequestsPage`)}}>view</button>
+          </div>
           {/* <OwnerCompletedRequest /> */}
           <div className='job-list-container'>{completedRequests.map((request) => {
             return (

--- a/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.jsx
+++ b/src/components/OwnerViewRequestsPage/OwnerViewRequestsPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, Link } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect, useState } from 'react';
 
@@ -49,7 +49,12 @@ function OwnerViewRequestsPage() {
 
         {/* render 4 recent active requests */}
         <div className="list-active-requests">
-          <h4>Active Requests:</h4>
+          <div className="active-requests-header">
+            <h4>Active Requests:</h4>
+            <div className="active-requests-view-btn">
+              <button onClick={()=>{history.push(`/OwnerActiveRequestsPage`)}}>view</button>
+            </div>
+          </div>
           <OwnerActiveRequest />
         </div>
         
@@ -58,7 +63,8 @@ function OwnerViewRequestsPage() {
 
         {/* render 4 recent completed requests */}
         <div className="active-box-container">
-          <button className='btn' onClick={viewCompletedList}>Completed Requests:</button>
+          {/* <button className='btn' onClick={viewCompletedList}>Completed Requests:</button> */}
+          <Link to="/OwnerCompletedRequestsPage"> Completed Requests:</Link>
           {/* <OwnerCompletedRequest /> */}
           <div className='job-list-container'>{completedRequests.map((request) => {
             return (


### PR DESCRIPTION
- on 'view requests page' displayed completed requests below active requests
- added view btns for active and completed requests page
- moved mapping data for completed requests to 'completed request' component instead of 'view requests page' to match active requests code